### PR TITLE
Remove unnecessary content type definition in Apollo HTTP link

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -11,9 +11,7 @@ import { HttpLink } from "apollo-link-http";
 import { BrowserRouter as Router } from "react-router-dom";
 
 const cache = new InMemoryCache();
-const link = new HttpLink({
-  headers: { "Content-Type": "application/json; charset=utf-8" },
-});
+const link = new HttpLink();
 
 const client: ApolloClient<NormalizedCacheObject> = new ApolloClient({
   cache,


### PR DESCRIPTION
On Google Chrome, this definition would be _appended_ to the default header value of `application/json`, making the final header value

```
content-type: application/json, application/json; charset=utf-8
```

which was rejected. Firefox apparently didn't do anything with the the (now removed) header definition at all, making it accidentally work.